### PR TITLE
Walk tool: take a leisurely stroll from systemd/ioc.sh to something close to your IOC boot script

### DIFF
--- a/walk.py
+++ b/walk.py
@@ -1,29 +1,71 @@
-import os
-import re
-import graphviz
-import string
-import pathlib
+#!/usr/bin/env python3
+"""
+Tool to walk scripts from ioc.service to startup, recording variables and
+dependencies.
 
-FILE_RE = re.compile(r"([^ =][/a-z_\-0-9$(){}\.]+)", re.IGNORECASE)
+This is not a "smart" tool in that it can't figure out control flow of your
+bash scripts.  If your scripts do anything beyond the basics, there is
+a chance this won't pick it up.  It will make a best-effort attempt to
+pick out newly-defined variables and propagate them through.
+
+Writes a graphviz digraph, if installed.
+
+May be run on non-PCDS machines with ``ioc_machine_core`` checked out, but
+results may vary significantly if the files aren't included in this repo.
+"""
+import argparse
+import collections
+import os
+import pathlib
+import pprint
+import re
+import string
+import sys
+import textwrap
+
+try:
+    import graphviz
+except ImportError:
+    graphviz = None
+
+
+FILE_RE = re.compile(r"([^ =\"':<>][/a-z_\-0-9$(){}\.]+)", re.IGNORECASE)
+EXPORT_RE = re.compile(r"^export\s*([^=\n\r]+)\s*=\s*([^\n]*)$", re.MULTILINE)
+NON_EXPORT_RE = re.compile(
+    r"^\s*([A-Za-z_][A-Za-z_0-9]+)\s*=([^\n]*)$", re.IGNORECASE | re.MULTILINE
+)
 
 MODULE_PATH = pathlib.Path(__file__).resolve().parent
-TOP_PATH = MODULE_PATH
-# TOP_PATH = pathlib.Path("/")
+if pathlib.Path("/reg/g").exists():
+    # PCDS machines
+    TOP_PATH = pathlib.Path("/")
+else:
+    # Used in isolation
+    TOP_PATH = MODULE_PATH
 
-hutch = "kfe"
-ioc_host = "ioc-kfe-mot-01"
-host_arch = "rhel7-x86_64"
 
-defines = {
-    "IOC_HOST": ioc_host,
-    "THISHOST": ioc_host,
-    "hutch": hutch,
-    "host": "",
-    "cfg": hutch,
-    "T_A": host_arch,
-}
+def build_arg_parser():
+    """Build the arg parser."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hutch", type=str, default="ued")
+    parser.add_argument("--ioc_host", type=str, default="ioc-ued-ccd01")
+    parser.add_argument("--host_arch", type=str, default="rhel7-x86_64")
+    parser.add_argument(
+        "--starting_script", type=str, default="usr/lib/systemd/scripts/ioc.sh"
+    )
+    return parser
 
-basic_config = f"""
+
+def get_basic_config(hutch, ioc_host, host_arch="rhel7-x86_64"):
+    basic_config = f"""
+IOC_HOST={ioc_host}
+THISHOST={ioc_host}
+host={ioc_host}
+cfg={hutch}
+T_A={host_arch}
+EPICS_HOST_ARCH={host_arch}
+
+hutch={hutch}
 CONFIG_SITE_TOP=/reg/g/pcds/pyps/config
 CTRL_REPO=file:///afs/slac/g/pcds/vol2/svn/pcds
 DATA_SITE_TOP=/reg/d
@@ -45,81 +87,180 @@ SETUP_SITE_TOP=/reg/g/pcds/setup
 TOOLS_SITE_TOP=/reg/common/tools
 """.strip()
 
-for basic_line in basic_config.splitlines():
-    key, value = basic_line.split('=')
-    if value.startswith("/"):
-        value = str(TOP_PATH) + value
-    defines[key] = str(value)
+    for basic_line in basic_config.splitlines():
+        if basic_line:
+            key, value = basic_line.split("=")
+            if value.startswith("/"):
+                value = str(TOP_PATH) + value[1:]
+            yield key, value
 
-checked = set()
-stack = [
-    ("START", "usr/lib/systemd/scripts/ioc.sh"),
-]
 
-links = {"START": {}}
-missing_keys = set()
-missing_files = set()
-bad_items = set()
+class TemplateState:
+    def __init__(self, hutch, ioc_host, host_arch, starting_script):
+        self.hutch = hutch
+        self.ioc_host = ioc_host
+        self.host_arch = host_arch
+        self.starting_script = starting_script
+        self.missing_keys = collections.defaultdict(set)
+        self.missing_files = collections.defaultdict(set)
+        self.bad_items = collections.defaultdict(set)
+        self.ignored_bad_items = {
+            prefix + str(idx) + suffix
+            for prefix, suffix in [("${", "}"), ("$", ""), ("${", ""), ("($", "")]
+            for idx in range(20)
+        }
+        self.variables = collections.defaultdict(list)
+        self.special_case_expansions = {
+            "$(${EPICS_BASE}/startup/EpicsHostArch)": host_arch,
+            "$(${EPICS_BASE}/startup/EpicsHostArch.pl)": host_arch,
+        }
+        self.template_variables = dict(
+            get_basic_config(
+                hutch=hutch,
+                ioc_host=ioc_host,
+                host_arch=host_arch,
+            )
+        )
 
-graph = graphviz.Digraph()
+    def expand_text(self, reference, text, allow_missing=False):
+        """Expand `text` with the current `template_variables`."""
+        if text in self.special_case_expansions:
+            return self.special_case_expansions[text]
 
-while stack:
-    parent_fn, fn = stack.pop()
-    if fn in checked:
-        continue
-    checked.add(fn)
-    # print(f"Saw: {fn}")
+        try:
+            return string.Template(text).substitute(self.template_variables)
+        except KeyError as ex:
+            key = str(ex).strip("'")
+            self.missing_keys[key].add(reference)
+            if not allow_missing:
+                raise
+            return text
 
-    if fn.startswith("/"):
-        fn = TOP_PATH / fn[1:]
+    def fix_filename(self, reference, fn):
+        """
+        Fix the given filename, expanding macros as necessary.
 
-    try:
-        fn = string.Template(str(fn)).substitute(defines)
-    except ValueError as ex:
-        bad_items.add((fn, str(ex)))
-        continue
-    except KeyError as ex:
-        print("Missing key", ex)
-        missing_keys.add(str(ex).strip("'"))
-        continue
+        Returns ``None`` if the file should be skipped.
+        """
+        fn = fn.strip("` \t\n\r|")
+        if fn.startswith("//"):
+            fn = "/" + fn.lstrip("/")
 
-    try:
-        with open(fn, "rt") as fp:
-            contents = fp.read()
-    except IsADirectoryError:
-        continue
-    except FileNotFoundError:
-        if '/' in fn:
-            missing_files.add(fn)
-        continue
+        try:
+            fn = self.expand_text(reference, fn)
+        except ValueError as ex:
+            if fn not in self.ignored_bad_items:
+                self.bad_items[reference].add((fn, str(ex)))
+            return
+        except KeyError as ex:
+            return
 
-    links[fn] = {}
-    links[parent_fn][fn] = links[fn]
-    graph.node(fn)
-    graph.edge(parent_fn, fn)
+        # More awful fix-ups:
+        fn = fn.strip("()")
 
-    print(f"<-- {fn} -->")
-    for item in FILE_RE.findall(contents):
-        item = item.strip()
-        if not item:
+        if fn.startswith("/"):
+            fn = str(TOP_PATH / fn[1:])
+
+        if fn.startswith("//"):
+            fn = "/" + fn.lstrip("/")
+
+        if not fn:
             ...
-        elif item.startswith("s/"):
+        elif fn.startswith("/dev/"):
             ...
-        elif item.startswith("*/"):
+        elif fn.startswith("s/"):
             ...
-        elif item.startswith("!"):
+        elif fn.startswith("*/"):
             ...
-        elif "/" in item:
-            stack.append((fn, item))
+        elif fn.startswith("!"):
+            ...
+        elif "/" in fn:
+            return fn
 
 
-print("Missing keys", list(sorted(missing_keys)))
-print("Bad items", list(sorted(bad_items)))
-print("Missing files:")
-for fn in sorted(missing_files):
-    print(f"    {fn}")
+def main(hutch, ioc_host, host_arch, starting_script):
+    templ = TemplateState(hutch, ioc_host, host_arch, starting_script)
+    stack = [
+        ("START", templ.fix_filename("START", starting_script)),
+        # ("START", "/reg/d/iocCommon/All/ued_env.sh"),
+    ]
 
-import pprint
-pprint.pprint(links)
+    graph = graphviz.Digraph() if graphviz is not None else None
+    links = {"START": {}}
+    checked = set()
 
-graph.render("links", format="pdf")
+    while stack:
+        reference, fn = stack.pop()
+        if fn in checked:
+            continue
+        checked.add(fn)
+
+        try:
+            with open(fn, "rt") as fp:
+                contents = fp.read()
+        except (UnicodeDecodeError, ValueError):
+            continue
+        except IsADirectoryError:
+            continue
+        except FileNotFoundError:
+            if "/" in fn and len(fn) > 5:
+                templ.missing_files[fn].add(reference)
+            continue
+
+        links[fn] = {}
+        links[reference][fn] = links[fn]
+        if graph is not None:
+            graph.node(fn)
+            graph.edge(reference, fn)
+
+        print(f"## {fn}")
+        print(textwrap.indent(contents, "    > ", lambda line: True))
+        for variable, value in EXPORT_RE.findall(contents):
+            print(f"Found export definition: {variable}={value}", file=sys.stderr)
+            templ.variables[variable].append((fn, value))
+            if variable not in templ.template_variables:
+                try:
+                    templ.template_variables[variable] = templ.expand_text(
+                        fn, value, allow_missing=True
+                    ).strip()
+                except ValueError:
+                    templ.template_variables[variable] = value.strip()
+
+        for variable, value in NON_EXPORT_RE.findall(contents):
+            print(f"Found non-export definition: {variable}={value}", file=sys.stderr)
+            templ.variables[variable].append((fn, value))
+
+        for item in FILE_RE.findall(contents):
+            item = templ.fix_filename(fn, item)
+            if item:
+                stack.append((fn, item))
+
+    for key, used_in in sorted(templ.missing_keys.items()):
+        print(f"! Missing key {key} used in {used_in}", file=sys.stderr)
+
+    for fn, items in sorted(templ.bad_items.items()):
+        for item, error in items:
+            print(f"! In {fn}, unable to evaluate {item!r}: {error}", file=sys.stderr)
+
+    for missing_fn, referred_by in sorted(templ.missing_files.items()):
+        for referred_by in sorted(referred_by):
+            print(f"! In {referred_by}, missing file {missing_fn!r}", file=sys.stderr)
+
+    for variable, defined_locations in sorted(templ.variables.items()):
+        for fn, value in defined_locations:
+            print(f"In {fn}, {variable}={value}")
+
+    if graph is not None:
+        graph.render("links", format="pdf")
+    return templ, links
+
+
+if __name__ == "__main__":
+    parser = build_arg_parser()
+    args = parser.parse_args()
+    main(
+        hutch=args.hutch,
+        ioc_host=args.ioc_host,
+        host_arch=args.host_arch,
+        starting_script=args.starting_script,
+    )

--- a/walk.py
+++ b/walk.py
@@ -1,0 +1,125 @@
+import os
+import re
+import graphviz
+import string
+import pathlib
+
+FILE_RE = re.compile(r"([^ =][/a-z_\-0-9$(){}\.]+)", re.IGNORECASE)
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parent
+TOP_PATH = MODULE_PATH
+# TOP_PATH = pathlib.Path("/")
+
+hutch = "kfe"
+ioc_host = "ioc-kfe-mot-01"
+host_arch = "rhel7-x86_64"
+
+defines = {
+    "IOC_HOST": ioc_host,
+    "THISHOST": ioc_host,
+    "hutch": hutch,
+    "host": "",
+    "cfg": hutch,
+    "T_A": host_arch,
+}
+
+basic_config = f"""
+CONFIG_SITE_TOP=/reg/g/pcds/pyps/config
+CTRL_REPO=file:///afs/slac/g/pcds/vol2/svn/pcds
+DATA_SITE_TOP=/reg/d
+EPICS_SETUP=/reg/g/pcds/setup
+EPICS_SITE_TOP=/reg/g/pcds/epics
+FACILITY_ROOT=/reg/g/pcds
+GIT_SITE_TOP=/afs/slac/g/cd/swe/git/repos
+GIT_TOP=/afs/slac/g/cd/swe/git/repos
+GW_SITE_TOP=/reg/g/pcds/gateway
+IOC_COMMON=/reg/d/iocCommon
+IOC_DATA=/reg/d/iocData
+PACKAGE_SITE_TOP=/reg/g/pcds/package
+PSPKG_ROOT=/reg/g/pcds/pkg_mgr
+PYAPPS_SITE_TOP=/reg/g/pcds/controls
+PYPS_ROOT=/reg/g/pcds/pyps/
+PYPS_SITE_TOP=/reg/g/pcds/pyps
+SCRIPTROOT=/reg/g/pcds/pyps/config/{hutch}/iocmanager
+SETUP_SITE_TOP=/reg/g/pcds/setup
+TOOLS_SITE_TOP=/reg/common/tools
+""".strip()
+
+for basic_line in basic_config.splitlines():
+    key, value = basic_line.split('=')
+    if value.startswith("/"):
+        value = str(TOP_PATH) + value
+    defines[key] = str(value)
+
+checked = set()
+stack = [
+    ("START", "usr/lib/systemd/scripts/ioc.sh"),
+]
+
+links = {"START": {}}
+missing_keys = set()
+missing_files = set()
+bad_items = set()
+
+graph = graphviz.Digraph()
+
+while stack:
+    parent_fn, fn = stack.pop()
+    if fn in checked:
+        continue
+    checked.add(fn)
+    # print(f"Saw: {fn}")
+
+    if fn.startswith("/"):
+        fn = TOP_PATH / fn[1:]
+
+    try:
+        fn = string.Template(str(fn)).substitute(defines)
+    except ValueError as ex:
+        bad_items.add((fn, str(ex)))
+        continue
+    except KeyError as ex:
+        print("Missing key", ex)
+        missing_keys.add(str(ex).strip("'"))
+        continue
+
+    try:
+        with open(fn, "rt") as fp:
+            contents = fp.read()
+    except IsADirectoryError:
+        continue
+    except FileNotFoundError:
+        if '/' in fn:
+            missing_files.add(fn)
+        continue
+
+    links[fn] = {}
+    links[parent_fn][fn] = links[fn]
+    graph.node(fn)
+    graph.edge(parent_fn, fn)
+
+    print(f"<-- {fn} -->")
+    for item in FILE_RE.findall(contents):
+        item = item.strip()
+        if not item:
+            ...
+        elif item.startswith("s/"):
+            ...
+        elif item.startswith("*/"):
+            ...
+        elif item.startswith("!"):
+            ...
+        elif "/" in item:
+            stack.append((fn, item))
+
+
+print("Missing keys", list(sorted(missing_keys)))
+print("Bad items", list(sorted(bad_items)))
+print("Missing files:")
+for fn in sorted(missing_files):
+    print(f"    {fn}")
+
+import pprint
+pprint.pprint(links)
+
+graph.render("links", format="pdf")


### PR DESCRIPTION
```
$ python walk.py  2>&1 |grep EPICS_CA_SERVER
...
In /reg/g/pcds/gateway/scripts/epicscagp, EPICS_CA_SERVER_PORT=5064
In /reg/g/pcds/setup/epics-ca-env.sh, EPICS_CA_SERVER_PORT=5064
In /reg/d/iocCommon/All/ued_env.sh, EPICS_CA_SERVER_PORT=5058
```

🤷‍♂️ 

Logical next step for https://confluence.slac.stanford.edu/display/PCDS/Detailed+Soft+IOC+boot+process
Helper script to do something similar and figure out where in the heck variables came from.

Generates fun graphs like the following:
![image](https://user-images.githubusercontent.com/5139267/115928213-9df3ef80-a43a-11eb-90ea-aedc08acb471.png)

This may or may not live here for long; I think some for of it may be good for `whatrecord`... though a PCDS-specific version of that.